### PR TITLE
Fixing "Operation not permitted" error when an nfs share is mounted i…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ else
         fi
 
         # Ensure proper permissions
-        chown -R "${USER_NAME}:${GROUP_NAME}" /app
+        chown -R "${USER_NAME}:${GROUP_NAME}" /app || true
 
         # Run as specified user
         exec gosu "${USER_NAME}" "$@"


### PR DESCRIPTION
…nside /app

Hi, i faced a bug on the latest build, when trying to run it as non-root. It didn't start up correctly and always logged:
```
spotizerr-1  | chown: changing ownership of '/app/downloads': Operation not permitted
spotizerr-1 exited with code 1
```

I found the issue happens when the entrypoint script tries to recursively set the permissions to the /app directory. I am using a NFS share mounted as a docker volume for my music storage. In my docker compose file this looks something like this:

```
volumes:
  music:
    driver_opts:
      type: "nfs"
      o: "addr=MYFILESERVERURL,nolock,soft,nfsvers=4"
      device: ":/PATHTOMYMUSICFOLDER"
```

This volume is then mounted under /app/downloads . I already set the NFS share to the correct permissions (1000:1000). When the entrypoint script tries to set the permissions it fails, because not even root is allowed to change the permissions of the nfs share root, producing the error message above.

I rebuild the docker container locally with this patch and this fixes my problem.
