### PR TITLE
Add UMASK Environment Variable Support and Documentation to docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,3 +12,4 @@ services:
     environment:
       - PUID=1000  # Replace with your desired user ID  | Remove both if you want to run as root (not recommended, might result in unreadable files)
       - PGID=1000  # Replace with your desired group ID | The user must have write permissions in the volume mapped to /app/downloads
+      - UMASK=0022 # Optional: Sets the default file permissions for newly created files within the container.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Set umask if UMASK variable is provided
+if [ -n "${UMASK}" ]; then
+    umask "${UMASK}"
+fi
+
 # Check if both PUID and PGID are not set
 if [ -z "${PUID}" ] && [ -z "${PGID}" ]; then
     # Run as root directly


### PR DESCRIPTION
This PR introduces the support for the `UMASK` environment variable in the `docker-compose.yml` file.

Changes include:
- Added a description for the `UMASK` variable to explain its purpose in setting default file permissions for newly created files within the container.
- Provided a usage example (0022 for user read/write and others read-only).

This update allows users to customize the file permission settings by adjusting the `UMASK` without modifying the container's internals.
