### PR TITLE
change redirect URI due to Spotify Developer dashboard changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In order for searching to work, you need to set up your own Spotify Developer ap
 4. Fill in:
    - App name (e.g., "My Spotizerr App")
    - App description
-   - Redirect URI: `http://localhost:7171/callback` (or your custom domain if exposed)
+   - Redirect URI: `http://127.0.0.1:7171/callback` (or your custom domain if exposed)
    - Check the Developer Terms agreement box
 5. Click "Create"
 6. On your app page, note your "Client ID" 


### PR DESCRIPTION
The Spotify Developer Dashboard no longer allows the use of http unless it's to the loopback address. It does not work even with "localhost".