### PR TITLE
use the HOST environment variable to bind to another interface than 0.0.0.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
     # Run with uvicorn
     uvicorn.run(
         app,
-        host="0.0.0.0",
+        host="${HOST:-0.0.0.0}",
         port=7171,
         log_level="info",
         access_log=True


### PR DESCRIPTION
I have external IPv6 only. So to use spotizerr I need to bind the application to [::] e.g. via an environment variable like HOST