### PR TITLE
feat: Separate tracks by user

### DIFF
--- a/routes/content/album.py
+++ b/routes/content/album.py
@@ -74,6 +74,7 @@ async def handle_download(album_id: str, request: Request, current_user: User = 
                 "url": url,
                 "name": name_from_spotify,
                 "artist": artist_from_spotify,
+                "username": current_user.username,
                 "orig_request": orig_params,
             }
         )

--- a/routes/content/playlist.py
+++ b/routes/content/playlist.py
@@ -96,6 +96,7 @@ async def handle_download(playlist_id: str, request: Request, current_user: User
                 "url": url,
                 "name": name_from_spotify,  # Use fetched name
                 "artist": artist_from_spotify,  # Use fetched owner name as artist
+                "username": current_user.username,
                 "orig_request": orig_params,
             }
         )

--- a/routes/content/track.py
+++ b/routes/content/track.py
@@ -74,6 +74,7 @@ async def handle_download(track_id: str, request: Request, current_user: User = 
                 "url": url,
                 "name": name_from_spotify,
                 "artist": artist_from_spotify,
+                "username": current_user.username,
                 "orig_request": orig_params,
             }
         )

--- a/routes/utils/celery_config.py
+++ b/routes/utils/celery_config.py
@@ -47,6 +47,7 @@ DEFAULT_MAIN_CONFIG = {
     "artistSeparator": "; ",
     "recursiveQuality": False,
     "spotifyMetadata": True,
+    "separateTracksByUser": False,
     "watch": {},
 }
 

--- a/spotizerr-ui/src/components/config/DownloadsTab.tsx
+++ b/spotizerr-ui/src/components/config/DownloadsTab.tsx
@@ -22,6 +22,7 @@ interface DownloadSettings {
   deezerQuality: "MP3_128" | "MP3_320" | "FLAC";
   spotifyQuality: "NORMAL" | "HIGH" | "VERY_HIGH";
   recursiveQuality: boolean; // frontend field (sent as camelCase to backend)
+  separateTracksByUser: boolean;
 }
 
 interface WatchConfig {
@@ -195,6 +196,13 @@ export function DownloadsTab({ config, isLoading }: DownloadsTabProps) {
           <label htmlFor="recursiveQualityToggle" className="text-content-primary dark:text-content-primary-dark">Recursive Quality</label>
           <input id="recursiveQualityToggle" type="checkbox" {...register("recursiveQuality")} className="h-6 w-6 rounded" />
         </div>
+        <div className="flex items-center justify-between">
+          <label htmlFor="separateTracksByUserToggle" className="text-content-primary dark:text-content-primary-dark">Separate tracks by user</label>
+          <input id="separateTracksByUserToggle" type="checkbox" {...register("separateTracksByUser")} className="h-6 w-6 rounded" />
+        </div>
+        <p className="text-sm text-content-muted dark:text-content-muted-dark">
+          When enabled, downloads will be organized in user-specific subdirectories (downloads/username/...)
+        </p>
         
         {/* Watch validation info */}
         {watchConfig?.enabled && (

--- a/spotizerr-ui/src/contexts/SettingsProvider.tsx
+++ b/spotizerr-ui/src/contexts/SettingsProvider.tsx
@@ -54,6 +54,7 @@ export type FlatAppSettings = {
   hlsThreads: number;
   // Frontend-only flag used in DownloadsTab
   recursiveQuality: boolean;
+  separateTracksByUser: boolean;
   // Add defaults for the new formatting properties
   track: string;
   album: string;
@@ -90,6 +91,7 @@ const defaultSettings: FlatAppSettings = {
   hlsThreads: 8,
   // Frontend-only default
   recursiveQuality: false,
+  separateTracksByUser: false,
   // Add defaults for the new formatting properties
   track: "{artist_name}/{album_name}/{track_number} - {track_name}",
   album: "{artist_name}/{album_name}",

--- a/spotizerr-ui/src/contexts/settings-context.ts
+++ b/spotizerr-ui/src/contexts/settings-context.ts
@@ -27,6 +27,7 @@ export interface AppSettings {
   m3u: boolean;
   hlsThreads: number;
   recursiveQuality: boolean;
+  separateTracksByUser: boolean;
   // Properties from the old 'formatting' object
   track: string;
   album: string;


### PR DESCRIPTION
# User-Specific Download Organization

## Summary
Implements a new configuration option that allows organizing downloads in user-specific subdirectories when multi-user authentication is enabled.

## Functionality
When enabled, this feature changes the download folder structure from:
```
downloads/...
```
To:
```
downloads/username/...
```

## Changes Implemented

### Backend
- **Configuration**: Added `separateTracksByUser` option to default backend config
- **Queue Manager**: Modified download queue manager to prepend username to directory format
- **API Endpoints**: Updated to pass username from API endpoints to download tasks

### Frontend
- **UI**: New toggle in Downloads tab with descriptive explanation
- **TypeScript**: Updated interfaces to include the new configuration option

## Benefits
- Better file organization in multi-user environments
- Clear separation of downloads by user
- Optional configuration that doesn't affect existing installations

## Requirements
- Only works when multi-user authentication is enabled
- Optional configuration (disabled by default)