### PR TITLE
feat: custom download path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ UMASK=0022
 # Whether to setup file permissions on startup. May improve performance on remote/slow filesystems
 SKIP_SET_PERMISSIONS=false
 
+# Custom download path. Leave empty to use default download directory
+CUSTOM_DOWNLOAD_PATH=
+
 ###
 ### Multi-user settings, disabled by default.
 ###

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: cooldockerizer93/spotizerr
     volumes:
     - ./data:/app/data
-    - ./downloads:/app/downloads
+    - ${CUSTOM_DOWNLOAD_PATH:-./downloads}:/app/downloads
     - ./logs:/app/logs
     ports:
     - 7171:7171


### PR DESCRIPTION
A configurable environment variable that allows users to specify a custom location for downloaded music files, replacing the default hardcoded download directory. This would be implemented through a CUSTOM_DOWNLOAD_PATH environment variable in Docker deployments.